### PR TITLE
unit tests and fixes

### DIFF
--- a/src/cryptographic_primitives/commitments/hash_commitment.rs
+++ b/src/cryptographic_primitives/commitments/hash_commitment.rs
@@ -17,6 +17,7 @@ use ::BigInteger as BigInt;
 
 use super::traits::Commitment;
 use super::ring::digest::{Context, SHA256};
+use arithmetic::traits::Samplable;
 
 pub struct HashCommitment;
 
@@ -33,6 +34,19 @@ impl Commitment for HashCommitment {
 
         BigInt::from(digest.finish().as_ref())
     }
+
+    fn create_commitment(
+        message: &BigInt, security_bits: &usize) -> (BigInt, BigInt)
+    {
+        let mut digest = Context::new(&SHA256);
+        let bytes_message: Vec<u8> = message.into();
+        digest.update(&bytes_message);
+        let blinding_factor = &(BigInt::sample(security_bits.clone()));
+        let bytes_blinding_factor: Vec<u8> = blinding_factor.into();
+        digest.update(&bytes_blinding_factor);
+
+        (BigInt::from(digest.finish().as_ref()), blinding_factor.clone())
+    }
 }
 
 #[cfg(test)]
@@ -40,13 +54,35 @@ mod tests {
     use ::BigInteger as BigInt;
     use super::Commitment;
     use super::HashCommitment;
+    use arithmetic::traits::Samplable;
+
 
     #[test]
-    // Very basic test here, TODO: suggest better testing
-    fn create_hash_commitment_test() {
-        let commitment = HashCommitment::create_commitment_with_user_defined_randomness(
-            &BigInt::one(), &BigInt::zero());
-
-        println!("{}", commitment);
+    fn hash_commitment_test() {
+        let sec_bits = 256;
+        let message = BigInt::sample(sec_bits.clone());
+        let (commitment, blind_factor) = HashCommitment::create_commitment(&message, &sec_bits);
+        let commitment2 = HashCommitment::create_commitment_with_user_defined_randomness(
+            &message, &blind_factor);
+        //test commitment length  - works because SHA256 output length the same as sec_bits
+        assert_eq!(commitment.bit_length(),sec_bits);
+        //test commitment correctness
+        assert_eq!(commitment, commitment2);
+        // debug:
+        //println!("commitment: {:?}", commitment.to_str_radix(16));
+        //println!("length: {:?}", commitment.bit_length());
     }
+
+    #[test]
+    fn hash_test() {
+
+        let mut digest = super::Context::new(&super::SHA256);
+        let message = BigInt::one();
+        let commitment = HashCommitment::create_commitment_with_user_defined_randomness(
+            &message, &BigInt::zero());
+        let message2: Vec<u8> = (&message).into();
+        digest.update(&message2);
+        assert_eq!(commitment, BigInt::from(digest.finish().as_ref()));
+    }
+
 }

--- a/src/cryptographic_primitives/commitments/hash_commitment.rs
+++ b/src/cryptographic_primitives/commitments/hash_commitment.rs
@@ -18,9 +18,9 @@ use ::BigInteger as BigInt;
 use super::traits::Commitment;
 use super::ring::digest::{Context, SHA256};
 use arithmetic::traits::Samplable;
-
+use super::{SECURITY_BITS};
 pub struct HashCommitment;
-const SECURITY_BITS : usize = 256;
+
 
 //TODO:  using the function with BigInt's as input instead of string's makes it impossible to commit to empty message or use empty randomness
 impl Commitment for HashCommitment {
@@ -58,23 +58,19 @@ mod tests {
     use super::Commitment;
     use super::HashCommitment;
     use arithmetic::traits::Samplable;
-    const SECURITY_BITS : usize = 256;
+    use super::{SECURITY_BITS};
 
     #[test]
     fn test_bit_length_create_commitment() {
         let message = BigInt::sample(SECURITY_BITS);
         let (commitment, blind_factor) = HashCommitment::create_commitment(&message);
         //test commitment length  - works because SHA256 output length the same as sec_bits
-        println!("blind_factor: {:?}", blind_factor.to_str_radix(16));
         assert_eq!(commitment.to_str_radix(16).len(),SECURITY_BITS/4);
         assert_eq!(blind_factor.to_str_radix(16).len(),SECURITY_BITS/4);
-
-
     }
 
     #[test]
     fn test_bit_length_create_commitment_with_user_defined_randomness() {
-
         let message = BigInt::sample(SECURITY_BITS);
         let (commitment, blind_factor) = HashCommitment::create_commitment(&message);
         let commitment2 = HashCommitment::create_commitment_with_user_defined_randomness(

--- a/src/cryptographic_primitives/commitments/mod.rs
+++ b/src/cryptographic_primitives/commitments/mod.rs
@@ -16,5 +16,7 @@
 
 extern crate ring;
 
+const SECURITY_BITS : usize = 256;
+
 pub mod traits;
 pub mod hash_commitment;

--- a/src/cryptographic_primitives/commitments/traits.rs
+++ b/src/cryptographic_primitives/commitments/traits.rs
@@ -21,5 +21,5 @@ pub trait Commitment {
         message: &BigInt, blinding_factor: &BigInt) -> BigInt;
 
     fn create_commitment(
-        message: &BigInt, security_bits: &usize) -> (BigInt, BigInt);
+        message: &BigInt) -> (BigInt, BigInt);
 }

--- a/src/cryptographic_primitives/commitments/traits.rs
+++ b/src/cryptographic_primitives/commitments/traits.rs
@@ -19,4 +19,7 @@ use ::BigInteger as BigInt;
 pub trait Commitment {
     fn create_commitment_with_user_defined_randomness(
         message: &BigInt, blinding_factor: &BigInt) -> BigInt;
+
+    fn create_commitment(
+        message: &BigInt, security_bits: &usize) -> (BigInt, BigInt);
 }

--- a/src/protocols/two_party_ecdsa/lindell_2017_keygen/party_one.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017_keygen/party_one.rs
@@ -21,7 +21,7 @@ use ::EC;
 use ::PK;
 use ::SK;
 
-const R_BYTES_SIZE : usize = 32;
+const SECURITY_BITS : usize = 256;
 
 use elliptic::curves::traits::*;
 
@@ -53,7 +53,7 @@ impl FirstMsgCommitments {
         let mut pk = PK::to_key(&ec_context, &EC::get_base_point());
         let sk = pk.randomize(&ec_context).to_big_uint();
 
-        let pk_commitment_blind_factor = BigInt::sample(R_BYTES_SIZE);
+        let pk_commitment_blind_factor = BigInt::sample(SECURITY_BITS);
         let pk_commitment = HashCommitment::create_commitment_with_user_defined_randomness(
             &pk.to_point().x, &pk_commitment_blind_factor);
 
@@ -69,7 +69,7 @@ impl FirstMsgCommitments {
                 &challenge, &sk, &EC::get_q()),
             &EC::get_q());
 
-        let zk_pok_blind_factor = BigInt::sample(R_BYTES_SIZE);
+        let zk_pok_blind_factor = BigInt::sample(SECURITY_BITS);
         let zk_pok_commitment = HashCommitment::create_commitment_with_user_defined_randomness(
             &pk_t_rand_commitment.to_point().x, &zk_pok_blind_factor);
 


### PR DESCRIPTION
- #7 
- added commitment without user defined randomness 
- made some changes to party_one.rs (sample bits instead of bytes)