### PR TITLE
Make sure to explicitly check DLog proof results

### DIFF
--- a/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
@@ -91,7 +91,6 @@ impl KeyGenFirstMsg {
 
 #[derive(Debug)]
 pub struct KeyGenSecondMsg {
-    pub d_log_proof_result: Result<(), ProofError>,
     pub pk_commitment_blind_factor: BigInt,
     pub zk_pok_blind_factor: BigInt,
     pub public_share: PK,
@@ -103,14 +102,14 @@ impl KeyGenSecondMsg {
         ec_context: &EC,
         first_message: &KeyGenFirstMsg,
         proof: &DLogProof,
-    ) -> KeyGenSecondMsg {
-        KeyGenSecondMsg {
-            d_log_proof_result: DLogProof::verify(ec_context, proof),
+    ) -> Result<KeyGenSecondMsg, ProofError> {
+        DLogProof::verify(ec_context, proof)?;
+        Ok(KeyGenSecondMsg {
             pk_commitment_blind_factor: first_message.pk_commitment_blind_factor.clone(),
             zk_pok_blind_factor: first_message.zk_pok_blind_factor.clone(),
             public_share: first_message.public_share.clone(),
             d_log_proof: first_message.d_log_proof.clone(),
-        }
+        })
     }
 }
 

--- a/src/protocols/two_party_ecdsa/lindell_2017/party_two.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/party_two.rs
@@ -45,16 +45,14 @@ impl KeyGenFirstMsg {
     }
 }
 #[derive(Debug)]
-pub struct KeyGenSecondMsg {
-    pub d_log_proof_result: Result<(), ProofError>,
-}
+pub struct KeyGenSecondMsg {}
 
 impl KeyGenSecondMsg {
     pub fn verify_commitments_and_dlog_proof(
         ec_context: &EC,
         party_one_first_messsage: &party_one::KeyGenFirstMsg,
         party_one_second_messsage: &party_one::KeyGenSecondMsg,
-    ) -> KeyGenSecondMsg {
+    ) -> Result<KeyGenSecondMsg, ProofError> {
         let mut flag = true;
         match party_one_first_messsage.pk_commitment
             == HashCommitment::create_commitment_with_user_defined_randomness(
@@ -77,12 +75,8 @@ impl KeyGenSecondMsg {
             true => flag = flag,
         };
         assert!(flag);
-        KeyGenSecondMsg {
-            d_log_proof_result: DLogProof::verify(
-                ec_context,
-                &party_one_second_messsage.d_log_proof,
-            ),
-        }
+        DLogProof::verify(ec_context, &party_one_second_messsage.d_log_proof)?;
+        Ok(KeyGenSecondMsg {})
     }
 }
 

--- a/src/protocols/two_party_ecdsa/lindell_2017/test.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/test.rs
@@ -14,15 +14,13 @@ mod tests {
             &ec_context,
             &party_one_first_message,
             &party_two_first_message.d_log_proof,
-        );
-        assert!(party_one_second_message.d_log_proof_result.is_ok());
+        ).expect("failed to verify and decommit");
 
-        let party_two_second_message =
+        let _party_two_second_message =
             party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
                 &ec_context,
                 &party_one_first_message,
                 &party_one_second_message,
-            );
-        assert!(party_two_second_message.d_log_proof_result.is_ok());
+            ).expect("failed to verify commitments and DLog proof");
     }
 }

--- a/tests/keygen_integ_test.rs
+++ b/tests/keygen_integ_test.rs
@@ -15,15 +15,13 @@ fn test_two_party_keygen() {
         &ec_context,
         &party_one_first_message,
         &party_two_first_message.d_log_proof,
-    );
-    assert!(party_one_second_message.d_log_proof_result.is_ok());
+    ).expect("failed to verify and decommit");
 
-    let party_two_second_message = party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
+    let _party_two_second_message = party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
         &ec_context,
         &party_one_first_message,
         &party_one_second_message,
-    );
-    assert!(party_two_second_message.d_log_proof_result.is_ok());
+    ).expect("failed to verify commitments and DLog proof");
 
     // init paillier keypair:
     let paillier_key_pair =

--- a/tests/signing_integ_test.rs
+++ b/tests/signing_integ_test.rs
@@ -25,15 +25,13 @@ fn test_two_party_sign() {
         &ec_context,
         &party_one_first_message,
         &party_two_first_message.d_log_proof,
-    );
-    assert!(party_one_second_message.d_log_proof_result.is_ok());
+    ).expect("party1 DLog proof failed");
 
-    let party_two_proof_result = party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
+    let _party_two_proof_result = party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
         &ec_context,
         &party_one_first_message,
         &party_one_second_message,
-    );
-    assert!(party_two_proof_result.d_log_proof_result.is_ok());
+    ).expect("party2 DLog proof failed");
 
     let message = BigInt::from(1234);
     let partial_sig = party_two::PartialSig::compute(


### PR DESCRIPTION
Otherwise, the protocol may continue while the verification failed.