### PR TITLE
support recovery ID

### DIFF
--- a/benches/two_party_ecdsa/lindell_2017/keygen.rs
+++ b/benches/two_party_ecdsa/lindell_2017/keygen.rs
@@ -14,7 +14,8 @@ mod bench {
             let party_one_second_message = party_one::KeyGenSecondMsg::verify_and_decommit(
                 &party_one_first_message,
                 &party_two_first_message.d_log_proof,
-            ).expect("failed to verify and decommit");
+            )
+            .expect("failed to verify and decommit");
 
             let _party_two_second_message =
                 party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
@@ -24,7 +25,8 @@ mod bench {
                     &party_one_second_message.public_share,
                     &party_one_second_message.pk_commitment_blind_factor,
                     &party_one_second_message.d_log_proof,
-                ).expect("failed to verify commitments and DLog proof");
+                )
+                .expect("failed to verify commitments and DLog proof");
 
             // init paillier keypair:
             let paillier_key_pair =
@@ -61,7 +63,8 @@ mod bench {
                 &challenge,
                 &encrypted_pairs,
                 &proof,
-            ).expect("");
+            )
+            .expect("");
         });
     }
 

--- a/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
@@ -254,10 +254,15 @@ impl Signature {
         let s_tag_tag = BigInt::mod_mul(&k1_inv, &s_tag.0, &temp.q());
         let s = cmp::min(s_tag_tag.clone(), &temp.q().clone() - s_tag_tag.clone());
 
+        /*
+         Calculate recovery id - it is not possible to compute the public key out of the signature
+         itself. Recovery id is used to enable extracting the public key uniquely.
+         1. id = R.y & 1
+         2. if (s > curve.q) id = id ^ 1
+        */
         let is_ry_odd = ry.tstbit(0);
         let mut recid = if is_ry_odd { 1 } else { 0 };
-        let half_q = &temp.q().div_floor(&BigInt::from(2));
-        if s_tag_tag.gt(half_q) {
+        if s_tag_tag.gt(&temp.q().div_floor(&BigInt::from(2))) {
             recid ^= 1;
         }
 

--- a/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
@@ -253,8 +253,9 @@ impl Signature {
         let s_tag_tag = BigInt::mod_mul(&k1_inv, &s_tag.0, &temp.q());
         let s = cmp::min(s_tag_tag.clone(), &temp.q().clone() - s_tag_tag.clone());
 
-        let is_ry_odd = !ry.modulus(&BigInt::from(2)).is_zero();
-        let recid = if is_ry_odd {1} else {0};
+        let is_ry_odd = ry.tstbit(0);
+        let recid = if is_ry_odd { 1 } else { 0 };
+
 
         Signature { s, r: rx, recid }
     }

--- a/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
@@ -65,6 +65,7 @@ pub struct PaillierKeyPair {
 pub struct Signature {
     pub s: BigInt,
     pub r: BigInt,
+    pub recid: u8,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -239,6 +240,7 @@ impl Signature {
         r = r.scalar_mul(&ephemeral_local_share.secret_share.get_element());
 
         let rx = r.x_coor().mod_floor(&temp.q());
+        let ry = r.y_coor().mod_floor(&temp.q());
         let k1_inv = &ephemeral_local_share
             .secret_share
             .to_big_int()
@@ -251,7 +253,10 @@ impl Signature {
         let s_tag_tag = BigInt::mod_mul(&k1_inv, &s_tag.0, &temp.q());
         let s = cmp::min(s_tag_tag.clone(), &temp.q().clone() - s_tag_tag.clone());
 
-        Signature { s, r: rx }
+        let is_ry_odd = !ry.modulus(&BigInt::from(2)).is_zero();
+        let recid = if is_ry_odd {1} else {0};
+
+        Signature { s, r: rx, recid }
     }
 }
 

--- a/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
@@ -193,7 +193,8 @@ impl PaillierKeyPair {
             &ek,
             RawPlaintext::from(keygen.secret_share.to_big_int()),
             &randomness,
-        ).0
+        )
+        .0
         .into_owned();
 
         PaillierKeyPair {

--- a/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/party_one.rs
@@ -254,8 +254,11 @@ impl Signature {
         let s = cmp::min(s_tag_tag.clone(), &temp.q().clone() - s_tag_tag.clone());
 
         let is_ry_odd = ry.tstbit(0);
-        let recid = if is_ry_odd { 1 } else { 0 };
-
+        let mut recid = if is_ry_odd { 1 } else { 0 };
+        let half_q = &temp.q().div_floor(&BigInt::from(2));
+        if s_tag_tag.gt(half_q) {
+            recid ^= 1;
+        }
 
         Signature { s, r: rx, recid }
     }

--- a/src/protocols/two_party_ecdsa/lindell_2017/test.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/test.rs
@@ -15,7 +15,8 @@ mod tests {
         let party_one_second_message = party_one::KeyGenSecondMsg::verify_and_decommit(
             &party_one_first_message,
             &party_two_first_message.d_log_proof,
-        ).expect("failed to verify and decommit");
+        )
+        .expect("failed to verify and decommit");
 
         let _party_two_second_message =
             party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
@@ -25,7 +26,8 @@ mod tests {
                 &party_one_second_message.public_share,
                 &party_one_second_message.pk_commitment_blind_factor,
                 &party_one_second_message.d_log_proof,
-            ).expect("failed to verify commitments and DLog proof");
+            )
+            .expect("failed to verify commitments and DLog proof");
     }
 
     #[test]
@@ -41,7 +43,8 @@ mod tests {
         let party_one_second_message = party_one::KeyGenSecondMsg::verify_and_decommit(
             &party_one_first_message,
             &party_two_first_message.d_log_proof,
-        ).expect("failed to verify and decommit");
+        )
+        .expect("failed to verify and decommit");
 
         let _party_two_second_message =
             party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
@@ -51,7 +54,8 @@ mod tests {
                 &party_one_second_message.public_share,
                 &party_one_second_message.pk_commitment_blind_factor,
                 &party_one_second_message.d_log_proof,
-            ).expect("failed to verify commitments and DLog proof");
+            )
+            .expect("failed to verify commitments and DLog proof");
 
         // init paillier keypair:
         let paillier_key_pair = party_one::PaillierKeyPair::generate_keypair_and_encrypted_share(
@@ -86,6 +90,7 @@ mod tests {
             &challenge,
             &encrypted_pairs,
             &proof,
-        ).expect("range proof error");
+        )
+        .expect("range proof error");
     }
 }

--- a/tests/keygen_integ_test.rs
+++ b/tests/keygen_integ_test.rs
@@ -12,7 +12,8 @@ fn test_two_party_keygen() {
     let party_one_second_message = party_one::KeyGenSecondMsg::verify_and_decommit(
         &party_one_first_message,
         &party_two_first_message.d_log_proof,
-    ).expect("failed to verify and decommit");
+    )
+    .expect("failed to verify and decommit");
 
     let _party_two_second_message = party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
         &party_one_first_message.pk_commitment,
@@ -21,7 +22,8 @@ fn test_two_party_keygen() {
         &party_one_second_message.public_share,
         &party_one_second_message.pk_commitment_blind_factor,
         &party_one_second_message.d_log_proof,
-    ).expect("failed to verify commitments and DLog proof");
+    )
+    .expect("failed to verify commitments and DLog proof");
 
     // init paillier keypair:
     let paillier_key_pair =
@@ -53,5 +55,6 @@ fn test_two_party_keygen() {
         &challenge,
         &encrypted_pairs,
         &proof,
-    ).expect("error range proof");
+    )
+    .expect("error range proof");
 }

--- a/tests/signing_integ_test.rs
+++ b/tests/signing_integ_test.rs
@@ -23,7 +23,8 @@ fn test_two_party_sign() {
     let party_one_second_message = party_one::KeyGenSecondMsg::verify_and_decommit(
         &party_one_first_message,
         &party_two_first_message.d_log_proof,
-    ).expect("party1 DLog proof failed");
+    )
+    .expect("party1 DLog proof failed");
 
     let _party_two_second_message = party_two::KeyGenSecondMsg::verify_commitments_and_dlog_proof(
         &party_one_first_message.pk_commitment,
@@ -32,7 +33,8 @@ fn test_two_party_sign() {
         &party_one_second_message.public_share,
         &party_one_second_message.pk_commitment_blind_factor,
         &party_one_second_message.d_log_proof,
-    ).expect("failed to verify commitments and DLog proof");
+    )
+    .expect("failed to verify commitments and DLog proof");
     let party2_private = party_two::Party2Private::set_private_key(&party_two_private_share_gen);
     let message = BigInt::from(1234);
     let partial_sig = party_two::PartialSig::compute(


### PR DESCRIPTION
calculate signature's `recid` as the following Secp256k1 implementation:
[https://github.com/bitcoin-core/secp256k1/blob/1e6f1f5ad5e7f1e3ef79313ec02023902bf8175c/src/ecdsa_impl.h#L292](https://github.com/bitcoin-core/secp256k1/blob/1e6f1f5ad5e7f1e3ef79313ec02023902bf8175c/src/ecdsa_impl.h#L292)
