### PR TITLE
Retrying request of failure

### DIFF
--- a/src/bin/gg18_keygen_client.rs
+++ b/src/bin/gg18_keygen_client.rs
@@ -353,11 +353,19 @@ where
     let addr = env::args()
         .nth(1)
         .unwrap_or("http://127.0.0.1:8001".to_string());
-    let res = client
+    let retries = 3;
+    let retry_delay = time::Duration::from_millis(250);
+    for _i in 1..retries {
+        let res = client
         .post(&format!("{}/{}", addr, path))
         .json(&body)
         .send();
-    Some(res.unwrap().text().unwrap())
+        if res.is_ok() {
+            return Some(res.unwrap().text().unwrap());
+        }
+        thread::sleep(retry_delay);
+    }
+    None
 }
 
 pub fn signup(client: &Client) -> Result<(PartySignup), ()> {

--- a/src/bin/gg18_keygen_client.rs
+++ b/src/bin/gg18_keygen_client.rs
@@ -357,9 +357,9 @@ where
     let retry_delay = time::Duration::from_millis(250);
     for _i in 1..retries {
         let res = client
-        .post(&format!("{}/{}", addr, path))
-        .json(&body)
-        .send();
+            .post(&format!("{}/{}", addr, path))
+            .json(&body)
+            .send();
         if res.is_ok() {
             return Some(res.unwrap().text().unwrap());
         }

--- a/src/bin/gg18_sign_client.rs
+++ b/src/bin/gg18_sign_client.rs
@@ -558,11 +558,19 @@ where
     let addr = env::args()
         .nth(1)
         .unwrap_or("http://127.0.0.1:8001".to_string());
-    let res = client
+    let retries = 3;
+    let retry_delay = time::Duration::from_millis(250);
+    for _i in 1..retries {
+        let res = client
         .post(&format!("{}/{}", addr, path))
         .json(&body)
         .send();
-    Some(res.unwrap().text().unwrap())
+        if res.is_ok() {
+            return Some(res.unwrap().text().unwrap());
+        }
+        thread::sleep(retry_delay);
+    }
+    None
 }
 
 pub fn signup(client: &Client) -> Result<(PartySignup), ()> {

--- a/src/bin/gg18_sign_client.rs
+++ b/src/bin/gg18_sign_client.rs
@@ -562,9 +562,9 @@ where
     let retry_delay = time::Duration::from_millis(250);
     for _i in 1..retries {
         let res = client
-        .post(&format!("{}/{}", addr, path))
-        .json(&body)
-        .send();
+            .post(&format!("{}/{}", addr, path))
+            .json(&body)
+            .send();
         if res.is_ok() {
             return Some(res.unwrap().text().unwrap());
         }


### PR DESCRIPTION
While sending a lot of requests to the shared state machine, some of them might fail because of network reasons. Consider making couple of retries for failed requests.