### PR TITLE
v0.1.0 candidate, use tagged versions dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 reqwest = {version = "0.9.5", default-features = false}
-rocket = { git = "https://github.com/SergioBenitez/Rocket.git", rev = "dcea9563fcb081874f862a4113d40f0172ed2113" }
-rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket.git", rev = "dcea9563fcb081874f862a4113d40f0172ed2113" }
+rocket = { version = "0.4.2", default-features = false }
+rocket_contrib = { version = "0.4.2", default-features = false, features = ["json"] }
 uuid = { version = "0.7", features = ["v4"] }
 rust-crypto = "^0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 reqwest = {version = "0.9.5", default-features = false}
-rocket = "0.4.2"
-rocket_contrib = "0.4.2"
+rocket = { git = "https://github.com/SergioBenitez/Rocket.git", rev = "dcea9563fcb081874f862a4113d40f0172ed2113" }
+rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket.git", rev = "dcea9563fcb081874f862a4113d40f0172ed2113" }
 uuid = { version = "0.7", features = ["v4"] }
 rust-crypto = "^0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,8 @@ categories = ["cryptography"]
 crate-type = ["lib"]
 
 [dependencies]
-paillier = { git = "https://github.com/KZen-networks/rust-paillier"}
-zk-paillier = { git = "https://github.com/KZen-networks/zk-paillier"}
-
+paillier = { git = "https://github.com/KZen-networks/rust-paillier", tag = "v0.3.0" }
+zk-paillier = { git = "https://github.com/KZen-networks/zk-paillier", tag = "v0.2.0" }
 
 hex = "0.3.2"
 subtle = {version = "2", features = ["nightly"]}
@@ -34,17 +33,19 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 reqwest = {version = "0.9.5", default-features = false}
-rocket = "0.4.0"
-rocket_contrib = "0.4.0"
+rocket = "0.4.2"
+rocket_contrib = "0.4.2"
 uuid = { version = "0.7", features = ["v4"] }
 rust-crypto = "^0.2"
 
 [dependencies.curv]
 git = "https://github.com/KZen-networks/curv"
+tag = "v0.2.0"
 features =  ["ec_secp256k1"]
 
 [dependencies.centipede]
 git = "https://github.com/KZen-networks/centipede"
+tag = "v0.2.0"
 
 [patch.crates-io]
 rust-gmp = { version = "0.5.0", features = ["serde_support"], git = "https://github.com/KZen-networks/rust-gmp" }

--- a/src/protocols/multi_party_ecdsa/gg_2018/party_i.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2018/party_i.rs
@@ -666,8 +666,6 @@ pub fn verify(sig: &Signature, y: &GE, message: &BigInt) -> Result<(), Error> {
     let gu1 = &g * &u1;
     let yu2 = y * &u2;
     // can be faster using shamir trick
-
-    ;
     if sig.r.clone() == ECScalar::from(&(gu1 + yu2).x_coor().unwrap().mod_floor(&FE::q())) {
         Ok(())
     } else {

--- a/src/protocols/multi_party_ecdsa/gg_2018/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2018/test.rs
@@ -390,5 +390,4 @@ mod tests {
             .output_signature(&s_vec)
             .expect("verification failed");
     }
-
 }

--- a/src/protocols/two_party_ecdsa/lindell_2017/test.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/test.rs
@@ -165,5 +165,4 @@ mod tests {
             party_one::compute_pubkey(&party1_private, &party_two_private_share_gen.public_share);
         party_one::verify(&signature, &pubkey, &message).expect("Invalid signature")
     }
-
 }


### PR DESCRIPTION
Note: `rocket` versions use specific commits, because latest tagged versions of `rocket` use `cookie = "0.11.1"` which is dependant on `ring = "0.13"`. 
This causes a dependancy hell when using this (multi-party-ecdsa) package together with other packages co-depending on `ring` but on a more advanced version (0.14).
Using this commit advances the transitive dependency to ring@0.14 and does not break the dependant repositories (I will follow up on https://github.com/SergioBenitez/Rocket/issues/1072 to see if that's getting into a tagged release on `rocket`).