### PR TITLE
fix address binding for "examples/sm_manager"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Run `./gg18_sign_client`. The application should be in the same folder as the `k
 
 Run `./run.sh` (located in `/demo` folder) in the same folder as the excutables (usually `/target/release/examples`. Move `params` file to the same folder). It will spawn a shared state machine, clients in the number of parties and signing requests for the `threshold + 1` first parties.
 
+`sm_manager` rocket server runs in _production_ mode by default. You may modify the `./run.sh` to config it to run in different environments. For example, to run rocket server in _development_:
+
+```
+ROCKET_ENV=development ./target/release/examples/sm_manager
+```
+
 |          !["Multiparty ECDSA Demo"][demo]          |
 | :------------------------------------------------: |
 | _A 5 parties setup with 3 signers (threshold = 2)_ |

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,5 +1,5 @@
 [development]
-address = "127.0.0.1"
+address = "0.0.0.0"
 port = 8001
 workers = 12
 keep_alive = 5
@@ -8,7 +8,7 @@ hi = "Hello!" # this is an unused extra; maybe application specific?
 is_extra = true # this is an unused extra; maybe application specific?
 
 [staging]
-address = "127.0.0.1"
+address = "0.0.0.0"
 port = 8001
 workers = 8
 keep_alive = 5
@@ -17,7 +17,7 @@ log = "normal"
 secret_key = "8Xui8SN4mI+7egV/9dlfYYLGQJeEx4+DwmSQLwDVXJg="
 
 [production]
-address = "127.0.0.1"
+address = "0.0.0.0"
 port = 8001
 workers = 12
 keep_alive = 5


### PR DESCRIPTION
"examples/sm_manager" is implemented using https://rocket.rs/

Current config Rocket.toml is incompatible with https://github.com/KZen-networks/multi-party-ecdsa/pull/88

This PR fixes the address config to support running sm_manager in docker.